### PR TITLE
Fix derender to work with empty config entries

### DIFF
--- a/lib/synchronizer.rb
+++ b/lib/synchronizer.rb
@@ -146,7 +146,7 @@ class Synchronizer
   end
 
   def derender(str)
-    string_attribues = @env.select {|k,v| v.class == String }
+    string_attribues = @env.select {|k,v| v.class == String && !v.strip.empty? }
     sorted_string_attribues = string_attribues.sort_by {|k, v| v.size * -1 }
     sorted_string_attribues.each { |k,v| str.gsub!(v, "<%= #{k} %>" ) }
 

--- a/spec/fixtures/config_with_empty.yml
+++ b/spec/fixtures/config_with_empty.yml
@@ -1,0 +1,8 @@
+---
+prod:
+  credentials:
+    api_key: "my_api_key"
+    app_key: "my_app_key"
+
+  deployment: "some-deployment"
+  some_unused_key: ""

--- a/spec/synchronizer_spec.rb
+++ b/spec/synchronizer_spec.rb
@@ -33,5 +33,13 @@ describe Synchronizer do
          "<%= deployment %> <%= diego_deployment %>")
          # not "<%= deployment %> <%= deployment%>-diego"
     end
+
+    context 'when a config property has an empty value' do
+      let(:synchronizer) { Synchronizer.new(File.join(fixtures, "config_with_empty.yml"), "prod", logger) }
+      it "ignores keys with empty values" do
+         expect(synchronizer.derender("some-deployment")).to eq(
+           "<%= deployment %>")
+      end
+    end
   end
 end


### PR DESCRIPTION
We encountered a problem where when we ran `get_screen_json_erb` if we had a config.yml that had a key with an empty value, for example:

```yml

batman:
  deployment: "cf-batman"

  micro_deployment: ""

```

The erb template generated would have "<%= micro_deployment %>" between each character in the template.

It works fine if the config.yml does not have any keys with blank values, however it seems like the change in derender that does a gsub! replacing "" with a key causes the issue.

Initially the ruby process hung, since our config had a few entries with blank values.
We investigated further and found the issue. The fix we made was to exclude config entries with blank values in  derender.

@msmykowski and @markstgodard 
