### PR TITLE
Change type of background job queue length graph

### DIFF
--- a/dashboard_templates/shared/cloud_controller_em_statistics.json.erb
+++ b/dashboard_templates/shared/cloud_controller_em_statistics.json.erb
@@ -2,11 +2,13 @@
   "graphs": [
     {
       "definition": {
-        "viz": "heatmap",
+        "viz": "timeseries",
         "requests": [
           {
-            "q": "avg:datadog.nozzle.cc.job_queue_length.cc_generic{$name} by {ip}",
-            "type": "area"
+            "q": "avg:datadog.nozzle.cc.job_queue_length.cc_generic{$name}",
+            "type": "line",
+            "conditional_formats": [],
+            "aggregator": "avg"
           }
         ],
         "events": [


### PR DESCRIPTION
A line chart was a little easier to read than a heatmap. The IP of this metric was not meaningful as the queue length is determined by the number of rows in a DB table, it is not specific to each worker.