### PR TITLE
Bump cc_jobs_queue_not_being_processed alert to 30m

### DIFF
--- a/alert_templates/shared/cf/cc_jobs_queue_not_being_processed.json.erb
+++ b/alert_templates/shared/cf/cc_jobs_queue_not_being_processed.json.erb
@@ -23,7 +23,7 @@
   "org_id": 4242,
   "overall_state": "OK",
   "overall_state_modified": "2017-05-26T11:32:27.271393+00:00",
-  "query": "min(last_10m):max:datadog.nozzle.cc.job_queue_length.total{deployment:<%= metron_agent_deployment %>} by {deployment} > 150",
+  "query": "min(last_30m):max:datadog.nozzle.cc.job_queue_length.total{deployment:<%= metron_agent_deployment %>} by {deployment} > 150",
   "tags": [
 
   ],


### PR DESCRIPTION
- For the last couple pages, the worker queue has drained on its own but
  it took a little longer than 10 minutes
- CAPI team will conduct an audit to ensure user-facing actions, like
  async service provisioning, use a higher priority than background
  cleanup jobs