### PR TITLE
Bump doppler RAM threshold aggregation time

### DIFF
--- a/alert_templates/tags/oss/cf_not_enough_free_RAM_bosh_doppler.json.erb
+++ b/alert_templates/tags/oss/cf_not_enough_free_RAM_bosh_doppler.json.erb
@@ -21,7 +21,7 @@
     },
     "timeout_h": null
   },
-  "query": "avg(last_15m):max:bosh.healthmonitor.system.mem.percent{deployment:<%= deployment %>,job:doppler} by {job,index} > 90",
+  "query": "avg(last_30m):max:bosh.healthmonitor.system.mem.percent{deployment:<%= deployment %>,job:doppler} by {job,index} > 90",
   "tags": [
 
   ],


### PR DESCRIPTION
- gives load shedding time to work
- avoid paging fatigue

Signed-off-by: Travis Patterson <tpatterson@pivotal.io>